### PR TITLE
Standardize color slugs

### DIFF
--- a/assets/css/blocks.css
+++ b/assets/css/blocks.css
@@ -33,7 +33,7 @@
 --------------------------------------------------------------*/
 
 .wp-block-cover.is-style-naledi-border {
-	border: 3px solid var(--wp--preset--color--dark-blue);
+	border: 3px solid var(--wp--preset--color--secondary);
 }
 .header-cover h2 {
     margin-bottom: 10px;
@@ -220,7 +220,7 @@
 --------------------------------------------------------------*/
 
 .wp-block-group.is-style-naledi-border {
-	border: 3px solid var(--wp--preset--color--dark-blue);
+	border: 3px solid var(--wp--preset--color--secondary);
 	padding: var(--wp--custom--spacing--vertical) var(--wp--custom--spacing--horizontal);
 }
 
@@ -235,7 +235,7 @@
 
 .wp-block-image.is-style-naledi-border img,
 .wp-block-image.is-style-naledi-image-frame img {
-	border: 3px solid var(--wp--preset--color--dark-blue);
+	border: 3px solid var(--wp--preset--color--secondary);
 }
 
 .wp-block-image.is-style-naledi-image-frame img {
@@ -251,14 +251,14 @@
 }
 
 .wp-block-latest-posts.is-style-naledi-latest-posts-dividers {
-	border-top: 3px solid var(--wp--preset--color--dark-blue);
-	border-bottom: 3px solid var(--wp--preset--color--dark-blue);
+	border-top: 3px solid var(--wp--preset--color--secondary);
+	border-bottom: 3px solid var(--wp--preset--color--secondary);
 }
 
 .wp-block-latest-posts.is-style-naledi-latest-posts-dividers:not(.is-grid) > li,
 .wp-block-latest-posts.is-style-naledi-latest-posts-dividers > li {
 	padding-bottom: var(--wp--custom--spacing--vertical);
-	border-bottom: 1px solid var(--wp--preset--color--dark-blue);
+	border-bottom: 1px solid var(--wp--preset--color--secondary);
 	margin-top: var(--wp--custom--spacing--vertical);
 	margin-bottom: var(--wp--custom--spacing--vertical);
 }
@@ -270,8 +270,8 @@
 }
 
 .wp-block-latest-posts.is-style-naledi-latest-posts-dividers.is-grid {
-	box-shadow: inset 0 -1px 0 0 var(--wp--preset--color--dark-blue);
-	border-bottom: 2px solid var(--wp--preset--color--dark-blue);
+	box-shadow: inset 0 -1px 0 0 var(--wp--preset--color--secondary);
+	border-bottom: 2px solid var(--wp--preset--color--secondary);
 }
 
 .wp-block-latest-posts.is-style-naledi-latest-posts-dividers.is-grid li {
@@ -312,7 +312,7 @@
 }
 
 .wp-block-latest-posts.is-style-naledi-latest-posts-borders li {
-	border: 3px solid var(--wp--preset--color--dark-blue);
+	border: 3px solid var(--wp--preset--color--secondary);
 	padding: var(--wp--custom--spacing--vertical) var(--wp--custom--spacing--horizontal);
 }
 
@@ -330,7 +330,7 @@
 --------------------------------------------------------------*/
 
 .wp-block-media-text.is-style-naledi-border {
-	border: 3px solid var(--wp--preset--color--dark-blue);
+	border: 3px solid var(--wp--preset--color--secondary);
 }
 
 /*--------------------------------------------------------------
@@ -371,7 +371,7 @@
 		height: 30px;
 	}
 	.wp-block-navigation .wp-block-navigation-link a {
-		color: var(--wp--preset--color--dark-blue);
+		color: var(--wp--preset--color--secondary);
 	}
 }
 
@@ -382,7 +382,7 @@
 
 hr,
 .wp-block-separator {
-	border-bottom: 1px solid var(--wp--preset--color--dark-blue);
+	border-bottom: 1px solid var(--wp--preset--color--secondary);
 	clear: both;
 	opacity: 1;
 }
@@ -391,7 +391,7 @@ hr[style*="text-align:right"],
 hr[style*="text-align: right"],
 .wp-block-separator[style*="text-align:right"],
 .wp-block-separator[style*="text-align: right"] {
-	border-right-color: var(--wp--preset--color--dark-blue);
+	border-right-color: var(--wp--preset--color--secondary);
 }
 
 hr.is-style-naledi-separator-thick,
@@ -498,7 +498,7 @@ li.current-menu-item.wp-block-navigation-link {
 }
 
 header {
-	background: var(--wp--preset--color--dark-blue);
+	background: var(--wp--preset--color--secondary);
     border-bottom: 1px solid rgba(0,0,0,.1);
 	color: var(--wp--preset--color--white);
 	padding-top: 50px;
@@ -540,7 +540,7 @@ footer {
 }
 
 .wp-block-post-date {
-	border: 2px solid var(--wp--preset--color--main-blue);
+	border: 2px solid var(--wp--preset--color--primary);
 	border-radius: 50px;
 	padding: 5px 10px;
     display: inline-block;

--- a/assets/css/style-shared.css
+++ b/assets/css/style-shared.css
@@ -41,12 +41,12 @@ textarea {
 }
 
 .comment-respond {
-	border: 2px solid var(--wp--preset--color--dark-blue);
+	border: 2px solid var(--wp--preset--color--secondary);
 	padding: 20px;
 }
 
 input#submit {
-	border: 2px solid var(--wp--preset--color--main-blue);
+	border: 2px solid var(--wp--preset--color--primary);
 	background: none;
     padding: 10px 20px;
     border-radius: 50px;
@@ -69,7 +69,7 @@ img.avatar {
 }
 
 .blog .wp-block-post-date {
-	border: 2px solid var(--wp--preset--color--main-blue);
+	border: 2px solid var(--wp--preset--color--primary);
 	border-radius: 50px;
 	padding: 5px 10px;
     display: inline-block;
@@ -77,7 +77,7 @@ img.avatar {
 }
 
 .single .wp-block-post-date {
-	border: 2px solid var(--wp--preset--color--main-blue);
+	border: 2px solid var(--wp--preset--color--primary);
 	border-radius: 50px;
 	display: inline-block;
 	padding: 5px 10px;
@@ -90,7 +90,7 @@ img.avatar {
 }
 
 input#submit {
-	color: var(--wp--preset--color--dark-blue);
+	color: var(--wp--preset--color--secondary);
 	font-size: 1em;
 }
 

--- a/block-templates/404.html
+++ b/block-templates/404.html
@@ -16,4 +16,4 @@
 <!-- wp:search {"label":"Search...","showLabel":false,"width":50,"widthUnit":"%","buttonText":"Search","buttonUseIcon":true,"align":"center"} /--></div></div>
 <!-- /wp:cover -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","backgroundColor":"yellow","className":"site-footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","backgroundColor":"septenary","className":"site-footer","layout":{"inherit":true}} /-->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -16,4 +16,4 @@
 <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","backgroundColor":"yellow","className":"site-footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","backgroundColor":"septenary","className":"site-footer","layout":{"inherit":true}} /-->

--- a/block-templates/page-about.html
+++ b/block-templates/page-about.html
@@ -109,8 +109,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:pullquote {"mainColor":"orange","className":"has-background has-orange-background-color is-style-solid-color"} -->
-<figure class="wp-block-pullquote has-background has-orange-background-color is-style-solid-color"><blockquote><p>Choose only one master—nature.</p><cite>Rembrandt</cite></blockquote></figure>
+<div class="wp-block-column"><!-- wp:pullquote {"mainColor":"tertiary","className":"has-background has-tertiary-background-color is-style-solid-color"} -->
+<figure class="wp-block-pullquote has-background has-tertiary-background-color is-style-solid-color"><blockquote><p>Choose only one master—nature.</p><cite>Rembrandt</cite></blockquote></figure>
 <!-- /wp:pullquote --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/block-templates/page-about.html
+++ b/block-templates/page-about.html
@@ -14,8 +14,8 @@
 <!-- /wp:spacer -->
 
 <!-- wp:buttons {"contentJustification":"center"} -->
-<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Book Now</strong></a></div>
+<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Book Now</strong></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->
@@ -89,8 +89,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:separator {"color":"main-blue","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-background has-main-blue-background-color has-main-blue-color is-style-wide"/>
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:separator {"color":"primary","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background has-primary-background-color has-primary-color is-style-wide"/>
 <!-- /wp:separator --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/block-templates/page-about.html
+++ b/block-templates/page-about.html
@@ -80,8 +80,8 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","backgroundColor":"pink","className":"naledi-history","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull naledi-history has-pink-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+<!-- wp:group {"align":"full","backgroundColor":"quinary","className":"naledi-history","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull naledi-history has-quinary-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.1","fontSize":"76px"}}} -->
 <p style="font-size:76px;line-height:1.1"><strong>Our History</strong></p>

--- a/block-templates/page-about.html
+++ b/block-templates/page-about.html
@@ -104,7 +104,7 @@
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:paragraph -->
-<p>Winding veils round their heads, the women walked on deck. They were now moving steadily down the river, passing the dark shapes of ships at anchor, and London was a swarm of lights with a pale yellow canopy drooping above it. There were the lights of the great theatres, the lights of the long streets, lights that indicated huge squares of domestic comfort, lights that hung high in air.</p>
+<p>Winding veils round their heads, the women walked on deck. They were now moving steadily down the river, passing the dark shapes of ships at anchor, and London was a swarm of lights with a pale septenary canopy drooping above it. There were the lights of the great theatres, the lights of the long streets, lights that indicated huge squares of domestic comfort, lights that hung high in air.</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
@@ -120,4 +120,4 @@
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","backgroundColor":"yellow","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","backgroundColor":"septenary","layout":{"inherit":true}} /-->

--- a/block-templates/page-home.html
+++ b/block-templates/page-home.html
@@ -139,8 +139,8 @@
     <!-- wp:group {"layout":{"contentSize":"1200px"},"className":"naledi-testimonials"} -->
     <div class="wp-block-group naledi-testimonials"><!-- wp:columns {"className":"is-style-naledi-columns-overlap"} -->
     <div class="wp-block-columns is-style-naledi-columns-overlap"><!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"blue","className":"is-style-default"} -->
-    <div class="wp-block-group is-style-default has-blue-background-color has-background"><!-- wp:group -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"quaternary","className":"is-style-default"} -->
+    <div class="wp-block-group is-style-default has-quaternary-background-color has-background"><!-- wp:group -->
     <div class="wp-block-group"><!-- wp:image {"align":"center","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
     <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large"><img alt=""/></figure></div>
     <!-- /wp:image -->

--- a/block-templates/page-home.html
+++ b/block-templates/page-home.html
@@ -14,8 +14,8 @@
     <!-- /wp:spacer -->
     
     <!-- wp:buttons {"contentJustification":"center"} -->
-    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
-    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Shop Now</strong></a></div>
+    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
+    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Shop Now</strong></a></div>
     <!-- /wp:button --></div>
     <!-- /wp:buttons --></div></div>
     <!-- /wp:cover -->
@@ -126,8 +126,8 @@
     <!-- /wp:spacer -->
     
     <!-- wp:buttons {"contentJustification":"center"} -->
-    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
-    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Book Now</strong></a></div>
+    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
+    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Book Now</strong></a></div>
     <!-- /wp:button --></div>
     <!-- /wp:buttons --></div></div>
     <!-- /wp:cover -->
@@ -211,12 +211,12 @@
     <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
     
-    <!-- wp:heading {"level":6,"textColor":"main-blue"} -->
-    <h6 class="has-main-blue-color has-text-color">ECOLOGY</h6>
+    <!-- wp:heading {"level":6,"textColor":"primary"} -->
+    <h6 class="has-primary-color has-text-color">ECOLOGY</h6>
     <!-- /wp:heading -->
     
-    <!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.1","fontSize":"5vw"}},"textColor":"dark-blue"} -->
-    <p class="has-dark-blue-color has-text-color" style="font-size:5vw;line-height:1.1"><strong>Natural resources.</strong></p>
+    <!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.1","fontSize":"5vw"}},"textColor":"secondary"} -->
+    <p class="has-secondary-color has-text-color" style="font-size:5vw;line-height:1.1"><strong>Natural resources.</strong></p>
     <!-- /wp:paragraph -->
     
     <!-- wp:spacer {"height":5} -->
@@ -227,8 +227,8 @@
     
     <!-- wp:columns {"align":"wide"} -->
     <div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.38%"} -->
-    <div class="wp-block-column" style="flex-basis:33.38%"><!-- wp:paragraph {"textColor":"dark-blue"} -->
-    <p class="has-dark-blue-color has-text-color"><em>Nature</em>, in the common sense, refers to essences unchanged by man; space, the air, the river, the leaf.&nbsp;<em>Art</em>&nbsp;is applied to the mixture of his will with the same things, as in a house, a canal, a statue, a picture. But his operations taken together are so insignificant, a little chipping, baking, patching, and washing, that in an impression so grand as that of the world on the human mind, they do not vary the result.</p>
+    <div class="wp-block-column" style="flex-basis:33.38%"><!-- wp:paragraph {"textColor":"secondary"} -->
+    <p class="has-secondary-color has-text-color"><em>Nature</em>, in the common sense, refers to essences unchanged by man; space, the air, the river, the leaf.&nbsp;<em>Art</em>&nbsp;is applied to the mixture of his will with the same things, as in a house, a canal, a statue, a picture. But his operations taken together are so insignificant, a little chipping, baking, patching, and washing, that in an impression so grand as that of the world on the human mind, they do not vary the result.</p>
     <!-- /wp:paragraph --></div>
     <!-- /wp:column -->
     
@@ -257,8 +257,8 @@
     <!-- /wp:column -->
     
     <!-- wp:column {"verticalAlignment":"center","width":"33%"} -->
-    <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:33%"><!-- wp:paragraph {"textColor":"dark-blue"} -->
-    <p class="has-dark-blue-color has-text-color">Undoubtedly we have no questions to ask which are unanswerable. We must trust the perfection of the creation so far, as to believe that whatever curiosity the order of things has awakened in our minds, the order of things can satisfy. Every man's condition is a solution in hieroglyphic to those inquiries he would put.</p>
+    <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:33%"><!-- wp:paragraph {"textColor":"secondary"} -->
+    <p class="has-secondary-color has-text-color">Undoubtedly we have no questions to ask which are unanswerable. We must trust the perfection of the creation so far, as to believe that whatever curiosity the order of things has awakened in our minds, the order of things can satisfy. Every man's condition is a solution in hieroglyphic to those inquiries he would put.</p>
     <!-- /wp:paragraph --></div>
     <!-- /wp:column --></div>
     <!-- /wp:columns -->

--- a/block-templates/page-home.html
+++ b/block-templates/page-home.html
@@ -268,4 +268,4 @@
     <!-- /wp:spacer --></div>
     <!-- /wp:group -->
     
-    <!-- wp:template-part {"slug":"footer","backgroundColor":"yellow","layout":{"inherit":true}} /-->
+    <!-- wp:template-part {"slug":"footer","backgroundColor":"septenary","layout":{"inherit":true}} /-->

--- a/block-templates/page-home.html
+++ b/block-templates/page-home.html
@@ -22,8 +22,8 @@
     
     <!-- wp:columns {"align":"full","className":"naledi-info"} -->
     <div class="wp-block-columns alignfull naledi-info"><!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"pink"} -->
-    <div class="wp-block-group has-pink-background-color has-background"><!-- wp:heading {"textAlign":"left","level":3} -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"quinary"} -->
+    <div class="wp-block-group has-quinary-background-color has-background"><!-- wp:heading {"textAlign":"left","level":3} -->
     <h3 class="has-text-align-left"><strong><a href="#">Virtual Tour</a></strong></h3>
     <!-- /wp:heading -->
     
@@ -153,8 +153,8 @@
     <!-- /wp:column -->
     
     <!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"pink","className":"is-style-default"} -->
-    <div class="wp-block-group is-style-default has-pink-background-color has-background"><!-- wp:group -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"quinary","className":"is-style-default"} -->
+    <div class="wp-block-group is-style-default has-quinary-background-color has-background"><!-- wp:group -->
     <div class="wp-block-group"><!-- wp:image {"align":"center","width":180,"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
     <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large is-resized"><img alt="" width="180"/></figure></div>
     <!-- /wp:image -->

--- a/block-templates/page-home.html
+++ b/block-templates/page-home.html
@@ -46,8 +46,8 @@
     <!-- /wp:column -->
     
     <!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"purple"} -->
-    <div class="wp-block-group has-purple-background-color has-background"><!-- wp:heading {"textAlign":"left","level":3} -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"senary"} -->
+    <div class="wp-block-group has-senary-background-color has-background"><!-- wp:heading {"textAlign":"left","level":3} -->
     <h3 class="has-text-align-left"><strong><a href="#">Our Products</a></strong></h3>
     <!-- /wp:heading -->
     
@@ -185,8 +185,8 @@
     <!-- /wp:column -->
     
     <!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"purple","className":"is-style-default"} -->
-    <div class="wp-block-group is-style-default has-purple-background-color has-background"><!-- wp:group -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"senary","className":"is-style-default"} -->
+    <div class="wp-block-group is-style-default has-senary-background-color has-background"><!-- wp:group -->
     <div class="wp-block-group"><!-- wp:image {"align":"center","width":180,"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
     <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large is-resized"><img alt="" width="180"/></figure></div>
     <!-- /wp:image -->

--- a/block-templates/page-news.html
+++ b/block-templates/page-news.html
@@ -70,4 +70,4 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","backgroundColor":"yellow","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","backgroundColor":"septenary","layout":{"inherit":true}} /-->

--- a/block-templates/page-news.html
+++ b/block-templates/page-news.html
@@ -14,8 +14,8 @@
     <!-- /wp:spacer -->
     
     <!-- wp:buttons {"contentJustification":"center"} -->
-    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
-    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Our Blog</strong></a></div>
+    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
+    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Our Blog</strong></a></div>
     <!-- /wp:button --></div>
     <!-- /wp:buttons --></div></div>
     <!-- /wp:cover -->

--- a/block-templates/page-services.html
+++ b/block-templates/page-services.html
@@ -140,8 +140,8 @@
 <!-- /wp:buttons --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"style":{"elements":{"link":{"color":{"text":"#000000"}}},"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}}},"backgroundColor":"yellow"} -->
-<div class="wp-block-column has-yellow-background-color has-background has-link-color" style="padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><!-- wp:heading {"style":{"typography":{"fontSize":"40px"}}} -->
+<!-- wp:column {"style":{"elements":{"link":{"color":{"text":"#000000"}}},"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}}},"backgroundColor":"septenary"} -->
+<div class="wp-block-column has-septenary-background-color has-background has-link-color" style="padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><!-- wp:heading {"style":{"typography":{"fontSize":"40px"}}} -->
 <h2 style="font-size:40px"><strong>Patron</strong></h2>
 <!-- /wp:heading -->
 
@@ -170,4 +170,4 @@
 <div style="height:80px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:template-part {"slug":"footer","backgroundColor":"yellow","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","backgroundColor":"septenary","layout":{"inherit":true}} /-->

--- a/block-templates/page-services.html
+++ b/block-templates/page-services.html
@@ -116,8 +116,8 @@
 <!-- /wp:buttons --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"style":{"elements":{"link":{"color":{"text":"#000000"}}},"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}}},"backgroundColor":"pink"} -->
-<div class="wp-block-column has-pink-background-color has-background has-link-color" style="padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><!-- wp:heading {"style":{"typography":{"fontSize":"40px"}}} -->
+<!-- wp:column {"style":{"elements":{"link":{"color":{"text":"#000000"}}},"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}}},"backgroundColor":"quinary"} -->
+<div class="wp-block-column has-quinary-background-color has-background has-link-color" style="padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><!-- wp:heading {"style":{"typography":{"fontSize":"40px"}}} -->
 <h2 style="font-size:40px"><strong>Family</strong></h2>
 <!-- /wp:heading -->
 

--- a/block-templates/page-services.html
+++ b/block-templates/page-services.html
@@ -92,8 +92,8 @@
 
 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"elements":{"link":{"color":{"text":"#000000"}}},"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}}},"backgroundColor":"blue"} -->
-<div class="wp-block-column has-blue-background-color has-background has-link-color" style="padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><!-- wp:heading {"style":{"typography":{"fontSize":"40px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"elements":{"link":{"color":{"text":"#000000"}}},"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}}},"backgroundColor":"quaternary"} -->
+<div class="wp-block-column has-quaternary-background-color has-background has-link-color" style="padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><!-- wp:heading {"style":{"typography":{"fontSize":"40px"}}} -->
 <h2 style="font-size:40px"><strong>Single</strong></h2>
 <!-- /wp:heading -->
 

--- a/block-templates/page-services.html
+++ b/block-templates/page-services.html
@@ -14,8 +14,8 @@
 <!-- /wp:spacer -->
 
 <!-- wp:buttons {"contentJustification":"center"} -->
-<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":"50px"}},"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Shop Now</strong></a></div>
+<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":"50px"}},"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Shop Now</strong></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->
@@ -31,8 +31,8 @@
 <h2>Before you arrive</h2>
 <!-- /wp:heading -->
 
-<!-- wp:cover {"url":"#","dimRatio":60,"overlayColor":"main-blue","minHeight":200,"align":"full"} -->
-<div class="wp-block-cover alignfull has-background-dim-60 has-main-blue-background-color has-background-dim" style="min-height:200px"><img class="wp-block-cover__image-background" alt="" src="#" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"54px"}}} -->
+<!-- wp:cover {"url":"#","dimRatio":60,"overlayColor":"primary","minHeight":200,"align":"full"} -->
+<div class="wp-block-cover alignfull has-background-dim-60 has-primary-background-color has-background-dim" style="min-height:200px"><img class="wp-block-cover__image-background" alt="" src="#" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"54px"}}} -->
 <h2 class="alignwide" style="font-size:54px">Wald.</h2>
 <!-- /wp:heading -->
 
@@ -110,8 +110,8 @@
 <!-- /wp:list -->
 
 <!-- wp:buttons {"contentJustification":"center","align":"full"} -->
-<div class="wp-block-buttons alignfull is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","width":100,"style":{"border":{"radius":"50px"}},"className":"is-style-fill"} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" style="border-radius:50px">$110 / year</a></div>
+<div class="wp-block-buttons alignfull is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","width":100,"style":{"border":{"radius":"50px"}},"className":"is-style-fill"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" style="border-radius:50px">$110 / year</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column -->
@@ -134,8 +134,8 @@
 <!-- /wp:list -->
 
 <!-- wp:buttons {"contentJustification":"center","align":"full"} -->
-<div class="wp-block-buttons alignfull is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","width":100,"style":{"border":{"radius":"50px"}},"className":"is-style-fill"} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" style="border-radius:50px">$200 / year</a></div>
+<div class="wp-block-buttons alignfull is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","width":100,"style":{"border":{"radius":"50px"}},"className":"is-style-fill"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" style="border-radius:50px">$200 / year</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column -->
@@ -158,8 +158,8 @@
 <!-- /wp:list -->
 
 <!-- wp:buttons {"contentJustification":"center","align":"full"} -->
-<div class="wp-block-buttons alignfull is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","width":100,"style":{"border":{"radius":"50px"}},"className":"is-style-fill"} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" style="border-radius:50px">$400 / year</a></div>
+<div class="wp-block-buttons alignfull is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","width":100,"style":{"border":{"radius":"50px"}},"className":"is-style-fill"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" style="border-radius:50px">$400 / year</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column --></div>

--- a/block-templates/page-sidebar.html
+++ b/block-templates/page-sidebar.html
@@ -90,4 +90,4 @@
     <div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
     
-    <!-- wp:template-part {"slug":"footer","backgroundColor":"yellow","layout":{"inherit":true}} /-->
+    <!-- wp:template-part {"slug":"footer","backgroundColor":"septenary","layout":{"inherit":true}} /-->

--- a/block-templates/page-sidebar.html
+++ b/block-templates/page-sidebar.html
@@ -59,7 +59,7 @@
     
     <!-- wp:column {"width":"33.62%"} -->
     <div class="wp-block-column" style="flex-basis:33.62%"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-    <figure class="wp-block-image size-large"><img alt="Wind turbines standing on a grassy plain, against a blue sky."/></figure>
+    <figure class="wp-block-image size-large"><img alt="Wind turbines standing on a grassy plain, against a quaternary sky."/></figure>
     <!-- /wp:image --></div>
     <!-- /wp:column --></div>
     <!-- /wp:columns --></div>

--- a/block-templates/page-sidebar.html
+++ b/block-templates/page-sidebar.html
@@ -14,8 +14,8 @@
     <!-- /wp:spacer -->
     
     <!-- wp:buttons {"contentJustification":"center"} -->
-    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
-    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Read More</strong></a></div>
+    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
+    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Read More</strong></a></div>
     <!-- /wp:button --></div>
     <!-- /wp:buttons --></div></div>
     <!-- /wp:cover -->
@@ -30,8 +30,8 @@
     <div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:group {"align":"full","style":{"color":{"background":"#f8f4e4"}}} -->
     <div class="wp-block-group alignfull has-background" style="background-color:#f8f4e4"><!-- wp:columns {"align":"wide"} -->
     <div class="wp-block-columns alignwide"><!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:heading {"level":6,"textColor":"main-blue"} -->
-    <h6 class="has-main-blue-color has-text-color">ECOLOGY</h6>
+    <div class="wp-block-column"><!-- wp:heading {"level":6,"textColor":"primary"} -->
+    <h6 class="has-primary-color has-text-color">ECOLOGY</h6>
     <!-- /wp:heading -->
     
     <!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.1","fontSize":"76px"}}} -->

--- a/block-templates/page-testimonials.html
+++ b/block-templates/page-testimonials.html
@@ -27,8 +27,8 @@
    <!-- wp:group {"align":"wide","className":"naledi-testimonials","layout":{"contentSize":"1200px"}} -->
     <div class="wp-block-group alignwide naledi-testimonials"><!-- wp:columns {"className":"is-style-naledi-columns-overlap"} -->
     <div class="wp-block-columns is-style-naledi-columns-overlap"><!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"blue","className":"is-style-default"} -->
-    <div class="wp-block-group is-style-default has-blue-background-color has-background"><!-- wp:group -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"quaternary","className":"is-style-default"} -->
+    <div class="wp-block-group is-style-default has-quaternary-background-color has-background"><!-- wp:group -->
     <div class="wp-block-group"><!-- wp:image {"align":"center","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
     <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large"><img alt="Testimonial"/></figure></div>
     <!-- /wp:image -->
@@ -99,8 +99,8 @@
     <!-- wp:group {"align":"wide","className":"naledi-testimonials","layout":{"contentSize":"1200px"}} -->
     <div class="wp-block-group alignwide naledi-testimonials"><!-- wp:columns {"className":"is-style-naledi-columns-overlap"} -->
     <div class="wp-block-columns is-style-naledi-columns-overlap"><!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"blue","className":"is-style-default"} -->
-    <div class="wp-block-group is-style-default has-blue-background-color has-background"><!-- wp:group -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"quaternary","className":"is-style-default"} -->
+    <div class="wp-block-group is-style-default has-quaternary-background-color has-background"><!-- wp:group -->
     <div class="wp-block-group"><!-- wp:image {"align":"center","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
     <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large"><img alt="Testimonial"/></figure></div>
     <!-- /wp:image -->

--- a/block-templates/page-testimonials.html
+++ b/block-templates/page-testimonials.html
@@ -132,4 +132,4 @@
     <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
     <!-- /wp:spacer -->
     
-    <!-- wp:template-part {"slug":"footer","backgroundColor":"yellow","layout":{"inherit":true}} /-->
+    <!-- wp:template-part {"slug":"footer","backgroundColor":"septenary","layout":{"inherit":true}} /-->

--- a/block-templates/page-testimonials.html
+++ b/block-templates/page-testimonials.html
@@ -63,8 +63,8 @@
     <!-- wp:group {"align":"wide","className":"naledi-testimonials","layout":{"contentSize":"1200px"}} -->
     <div class="wp-block-group alignwide naledi-testimonials"><!-- wp:columns {"className":"is-style-naledi-columns-overlap"} -->
     <div class="wp-block-columns is-style-naledi-columns-overlap"><!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"purple","className":"is-style-default"} -->
-    <div class="wp-block-group is-style-default has-purple-background-color has-background"><!-- wp:group -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"senary","className":"is-style-default"} -->
+    <div class="wp-block-group is-style-default has-senary-background-color has-background"><!-- wp:group -->
     <div class="wp-block-group"><!-- wp:image {"align":"center","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
     <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large"><img alt="Testimonial"/></figure></div>
     <!-- /wp:image -->

--- a/block-templates/page-testimonials.html
+++ b/block-templates/page-testimonials.html
@@ -41,8 +41,8 @@
     <!-- /wp:column -->
     
     <!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"pink","className":"is-style-default"} -->
-    <div class="wp-block-group is-style-default has-pink-background-color has-background"><!-- wp:group -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"quinary","className":"is-style-default"} -->
+    <div class="wp-block-group is-style-default has-quinary-background-color has-background"><!-- wp:group -->
     <div class="wp-block-group"><!-- wp:image {"align":"center","width":180,"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
     <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large is-resized"><img alt="" width="180"/></figure></div>
     <!-- /wp:image -->
@@ -113,8 +113,8 @@
     <!-- /wp:column -->
     
     <!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"pink","className":"is-style-default"} -->
-    <div class="wp-block-group is-style-default has-pink-background-color has-background"><!-- wp:group -->
+    <div class="wp-block-column"><!-- wp:group {"backgroundColor":"quinary","className":"is-style-default"} -->
+    <div class="wp-block-group is-style-default has-quinary-background-color has-background"><!-- wp:group -->
     <div class="wp-block-group"><!-- wp:image {"align":"center","width":180,"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
     <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large is-resized"><img alt="" width="180"/></figure></div>
     <!-- /wp:image -->

--- a/block-templates/page-testimonials.html
+++ b/block-templates/page-testimonials.html
@@ -14,8 +14,8 @@
     <!-- /wp:spacer -->
     
     <!-- wp:buttons {"contentJustification":"center"} -->
-    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
-    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Write a Review</strong></a></div>
+    <div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
+    <div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Write a Review</strong></a></div>
     <!-- /wp:button --></div>
     <!-- /wp:buttons --></div></div>
     <!-- /wp:cover -->

--- a/block-templates/page-tours.html
+++ b/block-templates/page-tours.html
@@ -14,8 +14,8 @@
 <!-- /wp:spacer -->
 
 <!-- wp:buttons {"contentJustification":"center"} -->
-<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Book Now</strong></a></div>
+<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>Book Now</strong></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->
@@ -33,8 +33,8 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:separator {"color":"main-blue","className":"is-style-wide is-style-default"} -->
-<hr class="wp-block-separator has-text-color has-background has-main-blue-background-color has-main-blue-color is-style-wide is-style-default"/>
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:separator {"color":"primary","className":"is-style-wide is-style-default"} -->
+<hr class="wp-block-separator has-text-color has-background has-primary-background-color has-primary-color is-style-wide is-style-default"/>
 <!-- /wp:separator --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
@@ -91,42 +91,42 @@
 <!-- wp:group {"className":"our-tours"} -->
 <div class="wp-block-group our-tours"><!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:cover {"url":"#","overlayColor":"main-blue"} -->
-<div class="wp-block-cover has-main-blue-background-color has-background-dim"><img class="wp-block-cover__image-background" alt="" src="#" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":3} -->
+<div class="wp-block-column"><!-- wp:cover {"url":"#","overlayColor":"primary"} -->
+<div class="wp-block-cover has-primary-background-color has-background-dim"><img class="wp-block-cover__image-background" alt="" src="#" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":3} -->
 <h3 class="has-text-align-center"><strong>Nature Tour</strong></h3>
 <!-- /wp:heading -->
 
 <!-- wp:buttons {"contentJustification":"center"} -->
-<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background">Book Now</a></div>
+<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background">Book Now</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:cover {"url":"#","overlayColor":"main-blue"} -->
-<div class="wp-block-cover has-main-blue-background-color has-background-dim"><img class="wp-block-cover__image-background" alt="" src="#" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":3} -->
+<div class="wp-block-column"><!-- wp:cover {"url":"#","overlayColor":"primary"} -->
+<div class="wp-block-cover has-primary-background-color has-background-dim"><img class="wp-block-cover__image-background" alt="" src="#" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":3} -->
 <h3 class="has-text-align-center"><strong>Walking Tour</strong>s</h3>
 <!-- /wp:heading -->
 
 <!-- wp:buttons {"contentJustification":"center"} -->
-<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background">Book Now</a></div>
+<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background">Book Now</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:cover {"url":"#","overlayColor":"main-blue"} -->
-<div class="wp-block-cover has-main-blue-background-color has-background-dim"><img class="wp-block-cover__image-background" alt="" src="#" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":3} -->
+<div class="wp-block-column"><!-- wp:cover {"url":"#","overlayColor":"primary"} -->
+<div class="wp-block-cover has-primary-background-color has-background-dim"><img class="wp-block-cover__image-background" alt="" src="#" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","level":3} -->
 <h3 class="has-text-align-center"><strong>Animal Tour</strong></h3>
 <!-- /wp:heading -->
 
 <!-- wp:buttons {"contentJustification":"center"} -->
-<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background">Book Now</a></div>
+<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background">Book Now</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover --></div>

--- a/block-templates/page-tours.html
+++ b/block-templates/page-tours.html
@@ -41,8 +41,8 @@
 
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"backgroundColor":"yellow"} -->
-<div class="wp-block-group has-yellow-background-color has-background"><!-- wp:image {"align":"center","width":150,"height":150,"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
+<div class="wp-block-column"><!-- wp:group {"backgroundColor":"septenary"} -->
+<div class="wp-block-group has-septenary-background-color has-background"><!-- wp:image {"align":"center","width":150,"height":150,"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
 <div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large is-resized"><img alt="" width="150" height="150"/></figure></div>
 <!-- /wp:image -->
 
@@ -54,7 +54,7 @@
 
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.5"}},"fontSize":"small"} -->
-<p class="has-small-font-size" style="line-height:1.5">Winding veils round their heads, the women walked on deck. They were now moving steadily down the river, passing the dark shapes of ships at anchor, and London was a swarm of lights with a pale yellow canopy drooping above it. There were the lights of the great theatres, the lights of the long streets, lights that indicated huge squares of domestic comfort, lights that hung high in air.</p>
+<p class="has-small-font-size" style="line-height:1.5">Winding veils round their heads, the women walked on deck. They were now moving steadily down the river, passing the dark shapes of ships at anchor, and London was a swarm of lights with a pale septenary canopy drooping above it. There were the lights of the great theatres, the lights of the long streets, lights that indicated huge squares of domestic comfort, lights that hung high in air.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:gallery {"linkTo":"none"} -->
@@ -134,4 +134,4 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","backgroundColor":"yellow","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","backgroundColor":"septenary","layout":{"inherit":true}} /-->

--- a/block-templates/page.html
+++ b/block-templates/page.html
@@ -18,4 +18,4 @@
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","backgroundColor":"yellow","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","backgroundColor":"septenary","layout":{"inherit":true}} /-->

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -42,4 +42,4 @@
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","backgroundColor":"yellow","className":"site-footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","backgroundColor":"septenary","className":"site-footer","layout":{"inherit":true}} /-->

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -92,8 +92,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			<!-- /wp:column -->
 			
 			<!-- wp:column -->
-			<div class="wp-block-column"><!-- wp:group {"backgroundColor":"purple"} -->
-			<div class="wp-block-group has-purple-background-color has-background"><!-- wp:heading {"textAlign":"center","level":3} -->
+			<div class="wp-block-column"><!-- wp:group {"backgroundColor":"senary"} -->
+			<div class="wp-block-group has-senary-background-color has-background"><!-- wp:heading {"textAlign":"center","level":3} -->
 			<h3 class="has-text-align-center"><strong><a href="#">' . esc_html__( 'Our Products', 'naledi' ) . '</a></strong></h3>
 			<!-- /wp:heading -->
 			

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -173,8 +173,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			'content'       => '<!-- wp:group {"align":"wide","layout":{"contentSize":"1200px"}} -->
 			<div class="wp-block-group alignwide"><!-- wp:columns {"className":"is-style-naledi-columns-overlap"} -->
 			<div class="wp-block-columns is-style-naledi-columns-overlap"><!-- wp:column -->
-			<div class="wp-block-column"><!-- wp:group {"backgroundColor":"blue","className":"is-style-default"} -->
-			<div class="wp-block-group is-style-default has-blue-background-color has-background"><!-- wp:group -->
+			<div class="wp-block-column"><!-- wp:group {"backgroundColor":"quaternary","className":"is-style-default"} -->
+			<div class="wp-block-group is-style-default has-quaternary-background-color has-background"><!-- wp:group -->
 			<div class="wp-block-group"><!-- wp:image {"align":"center","sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
 			<div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large"><img src="' . esc_url( get_theme_file_uri( 'assets/images/testimonial.jpg' ) ) . '" alt="Testimonial" /></figure></div>
 			<!-- /wp:image -->

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -68,8 +68,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			'description'   => esc_html_x( 'Info bar with three columns', 'Block pattern description', 'naledi' ),
 			'content'       => '<!-- wp:columns {"align":"full","className":"naledi-info"} -->
 			<div class="wp-block-columns alignfull naledi-info"><!-- wp:column -->
-			<div class="wp-block-column"><!-- wp:group {"backgroundColor":"pink"} -->
-			<div class="wp-block-group has-pink-background-color has-background"><!-- wp:heading {"textAlign":"center","level":3} -->
+			<div class="wp-block-column"><!-- wp:group {"backgroundColor":"quinary"} -->
+			<div class="wp-block-group has-quinary-background-color has-background"><!-- wp:heading {"textAlign":"center","level":3} -->
 			<h3 class="has-text-align-center"><strong><a href="#">' . esc_html__( 'Virtual Tour', 'naledi' ) . '</a></strong></h3>
 			<!-- /wp:heading -->
 			
@@ -187,8 +187,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			<!-- /wp:column -->
 			
 			<!-- wp:column -->
-			<div class="wp-block-column"><!-- wp:group {"backgroundColor":"pink","className":"is-style-default"} -->
-			<div class="wp-block-group is-style-default has-pink-background-color has-background"><!-- wp:group -->
+			<div class="wp-block-column"><!-- wp:group {"backgroundColor":"quinary","className":"is-style-default"} -->
+			<div class="wp-block-group is-style-default has-quinary-background-color has-background"><!-- wp:group -->
 			<div class="wp-block-group"><!-- wp:image {"align":"center","width":180,"sizeSlug":"large","linkDestination":"none","className":"is-style-rounded"} -->
 			<div class="wp-block-image is-style-rounded"><figure class="aligncenter size-large is-resized"><img src="' . esc_url( get_theme_file_uri( 'assets/images/testimonial-1.jpeg' ) ) . '" alt="" width="180"/></figure></div>
 			<!-- /wp:image -->

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -50,8 +50,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			<!-- /wp:spacer -->
 			
 			<!-- wp:buttons {"contentJustification":"center"} -->
-			<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"main-blue","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
-			<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-main-blue-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>' . esc_html__( 'Book Now', 'naledi' ) . '</strong></a></div>
+			<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"backgroundColor":"white","textColor":"primary","style":{"border":{"radius":50}},"className":"is-style-outline"} -->
+			<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-white-background-color has-text-color has-background" href="#" style="border-radius:50px"><strong>' . esc_html__( 'Book Now', 'naledi' ) . '</strong></a></div>
 			<!-- /wp:button --></div>
 			<!-- /wp:buttons --></div></div>
 			<!-- /wp:cover -->',

--- a/style.css
+++ b/style.css
@@ -63,3 +63,54 @@ body {
     from { opacity: 0; }
     to   { opacity: 1; }
 }
+
+/*--------------------------------------------------------------
+# Color fallbacks
+--------------------------------------------------------------*/
+.has-main-blue-background-color {
+	background-color: var(--wp--preset--color--primary);
+}
+
+.has-dark-blue-background-color {
+	background-color: var(--wp--preset--color--secondary);
+}
+
+.has-orange-background-color {
+	background-color: var(--wp--preset--color--tertiary);
+}
+
+.has-blue-background-color {
+	background-color: var(--wp--preset--color--quaternary);
+}
+
+.has-pink-background-color {
+	background-color: var(--wp--preset--color--quinary);
+}
+
+.has-purple-background-color {
+	background-color: var(--wp--preset--color--senary);
+}
+
+.has-main-blue-color {
+	color: var(--wp--preset--color--primary);
+}
+
+.has-dark-blue-color {
+	color: var(--wp--preset--color--secondary);
+}
+
+.has-orange-color {
+	color: var(--wp--preset--color--tertiary);
+}
+
+.has-blue-color {
+	color: var(--wp--preset--color--quaternary);
+}
+
+.has-pink-color {
+	color: var(--wp--preset--color--quinary);
+}
+
+.has-purple-color {
+	color: var(--wp--preset--color--senary);
+}

--- a/theme.json
+++ b/theme.json
@@ -53,33 +53,33 @@
 
 			"gradients": [
 				{
-					"slug": "quinary-to-yellow",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--quinary), var(--wp--preset--color--yellow))",
+					"slug": "quinary-to-septenary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--quinary), var(--wp--preset--color--septenary))",
 					"name": "Pink to Yellow"
 				},
 				{
-					"slug": "yellow-to-quinary",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--quinary))",
+					"slug": "septenary-to-quinary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--septenary), var(--wp--preset--color--quinary))",
 					"name": "Yellow to Pink"
 				},
 				{
-					"slug": "tertiary-to-yellow",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--tertiary), var(--wp--preset--color--yellow))",
+					"slug": "tertiary-to-septenary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--tertiary), var(--wp--preset--color--septenary))",
 					"name": "Orange to Yellow"
 				},
 				{
-					"slug": "yellow-to-tertiary",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--tertiary))",
+					"slug": "septenary-to-tertiary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--septenary), var(--wp--preset--color--tertiary))",
 					"name": "Yellow to Orange"
 				},
 				{
-					"slug": "senary-to-yellow",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--senary), var(--wp--preset--color--yellow))",
+					"slug": "senary-to-septenary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--senary), var(--wp--preset--color--septenary))",
 					"name": "Purple to Yellow"
 				},
 				{
-					"slug": "yellow-to-senary",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--senary))",
+					"slug": "septenary-to-senary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--septenary), var(--wp--preset--color--senary))",
 					"name": "Yellow to Purple"
 				},
 				{

--- a/theme.json
+++ b/theme.json
@@ -73,23 +73,23 @@
 					"name": "Yellow to Orange"
 				},
 				{
-					"slug": "purple-to-yellow",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
+					"slug": "senary-to-yellow",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--senary), var(--wp--preset--color--yellow))",
 					"name": "Purple to Yellow"
 				},
 				{
-					"slug": "yellow-to-purple",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
+					"slug": "yellow-to-senary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--senary))",
 					"name": "Yellow to Purple"
 				},
 				{
-					"slug": "quinary-to-purple",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--quinary), var(--wp--preset--color--purple))",
+					"slug": "quinary-to-senary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--quinary), var(--wp--preset--color--senary))",
 					"name": "Pink to Purple"
 				},
 				{
-					"slug": "purple-to-quinary",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--quinary))",
+					"slug": "senary-to-quinary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--senary), var(--wp--preset--color--quinary))",
 					"name": "Purple to Pink"
 				}
 			]

--- a/theme.json
+++ b/theme.json
@@ -5,50 +5,50 @@
 			"link": true,
 			"palette": [
 				{
-					"slug": "black",
-					"color": "#000000",
-					"name": "Black"
-				},
-				{
-					"slug": "dark-blue",
-					"color": "#172345",
-					"name": "Dark Blue"
-				},
-				{
-					"slug": "main-blue",
+					"slug": "primary",
 					"color": "#4144BF",
 					"name": "Main Blue"
 				},
 				{
-					"slug": "orange",
+					"slug": "secondary",
+					"color": "#172345",
+					"name": "Dark Blue"
+				},
+				{
+					"slug": "tertiary",
 					"color": "#FDF8F5",
 					"name": "Orange"
 				},
 				{
-					"slug": "blue",
+					"slug": "quaternary",
 					"color": "#E4F5FB",
 					"name": "Blue"
 				},
 				{
-					"slug": "pink",
+					"slug": "quinary",
 					"color": "#EEDCEB",
 					"name": "Pink"
 				},
 				{
-					"slug": "purple",
+					"slug": "senary",
 					"color": "#E2E1F3",
 					"name": "Purple"
 				},
 				{
-					"slug": "yellow",
+					"slug": "septenary",
 					"color": "#EEEADD",
 					"name": "Yellow"
 				},
 				{
-					"slug": "white",
+					"slug": "background",
 					"color": "#FFFFFF",
 					"name": "White"
-				}
+				},
+				{
+					"slug": "foreground",
+					"color": "#000000",
+					"name": "Black"
+				},
 			],
 
 			"gradients": [
@@ -182,7 +182,7 @@
 	"styles": {
 		"color": {
 			"background": "var(--wp--preset--color--white)",
-			"text": "var(--wp--preset--color--dark-blue)"
+			"text": "var(--wp--preset--color--secondary)"
 		},
 		"typography": {
 			"fontSize": "var(--wp--preset--font-size--normal)",
@@ -192,12 +192,12 @@
 		"elements": {
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--main-blue)"
+					"text": "var(--wp--preset--color--primary)"
 				}
 			},
 			"h1": {
 				"color": {
-					"text": "var(--wp--preset--color--dark-blue)"
+					"text": "var(--wp--preset--color--secondary)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--gigantic)"
@@ -205,7 +205,7 @@
 			},
 			"h2": {
 				"color": {
-					"text": "var(--wp--preset--color--dark-blue)"
+					"text": "var(--wp--preset--color--secondary)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--extra-large)"

--- a/theme.json
+++ b/theme.json
@@ -53,13 +53,13 @@
 
 			"gradients": [
 				{
-					"slug": "pink-to-yellow",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--pink), var(--wp--preset--color--yellow))",
+					"slug": "quinary-to-yellow",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--quinary), var(--wp--preset--color--yellow))",
 					"name": "Pink to Yellow"
 				},
 				{
-					"slug": "yellow-to-pink",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--pink))",
+					"slug": "yellow-to-quinary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--quinary))",
 					"name": "Yellow to Pink"
 				},
 				{
@@ -83,13 +83,13 @@
 					"name": "Yellow to Purple"
 				},
 				{
-					"slug": "pink-to-purple",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--pink), var(--wp--preset--color--purple))",
+					"slug": "quinary-to-purple",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--quinary), var(--wp--preset--color--purple))",
 					"name": "Pink to Purple"
 				},
 				{
-					"slug": "purple-to-pink",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--pink))",
+					"slug": "purple-to-quinary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--quinary))",
 					"name": "Purple to Pink"
 				}
 			]

--- a/theme.json
+++ b/theme.json
@@ -63,13 +63,13 @@
 					"name": "Yellow to Pink"
 				},
 				{
-					"slug": "orange-to-yellow",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--orange), var(--wp--preset--color--yellow))",
+					"slug": "tertiary-to-yellow",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--tertiary), var(--wp--preset--color--yellow))",
 					"name": "Orange to Yellow"
 				},
 				{
-					"slug": "yellow-to-orange",
-					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--orange))",
+					"slug": "yellow-to-tertiary",
+					"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--tertiary))",
 					"name": "Yellow to Orange"
 				},
 				{

--- a/theme.json
+++ b/theme.json
@@ -48,7 +48,7 @@
 					"slug": "foreground",
 					"color": "#000000",
 					"name": "Black"
-				},
+				}
 			],
 
 			"gradients": [


### PR DESCRIPTION
Does the same as https://github.com/anarieldesign/clove/pull/1, so that when switching themes colors are retained. 

### With these PRs applied, Naledi -> Clove:

<img width="1231" alt="Screen Shot 2021-07-22 at 9 54 00 AM" src="https://user-images.githubusercontent.com/1813435/126651588-dbe5a4fe-c6bd-4dc6-9780-9d31b532a188.png">
<img width="1240" alt="Screen Shot 2021-07-22 at 9 54 06 AM" src="https://user-images.githubusercontent.com/1813435/126651612-f3edec03-8074-4902-8ec1-124569806197.png">

### **Without** these PRs applied: 
( Looses colors, as the color classes do not match)
<img width="1231" alt="Screen Shot 2021-07-22 at 9 54 00 AM" src="https://user-images.githubusercontent.com/1813435/126651588-dbe5a4fe-c6bd-4dc6-9780-9d31b532a188.png">
<img width="1295" alt="Screen Shot 2021-07-22 at 10 00 00 AM" src="https://user-images.githubusercontent.com/1813435/126651722-dc1ab4e3-8a18-4402-8ddb-2b1b8addd523.png">

